### PR TITLE
Add Docker Image and Docker Compose

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,8 @@
+# copy as .env in order to run the application locally via dockercompose
+
+# database information for connecting to the local dmap rds
+DB_HOST=dmap_local_rds
+DB_PORT=5432
+DB_NAME=dmap_importer
+DB_USER=postgres
+DB_PASSWORD=postgres

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.12-slim
+
+# Prevents buffering for easier container logging
+ENV PYTHONUNBUFFERED 1
+
+# Install non python dependencies
+RUN apt-get update
+RUN apt-get install -y libpq-dev curl
+
+# Fetch Amazon RDS certificate chain
+RUN curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem -o /usr/local/share/amazon-certs.pem
+RUN echo "d464378fbb8b981d2b28a1deafffd0113554e6adfb34535134f411bf3c689e73 /usr/local/share/amazon-certs.pem" | sha256sum -c -
+RUN chmod a=r /usr/local/share/amazon-certs.pem
+
+# Install poetry
+RUN pip install -U pip
+RUN pip install "poetry==1.6.1"
+
+WORKDIR /dmap_importer
+
+# copy pyproject, readme, and source code into the container
+COPY pyproject.toml pyproject.toml
+COPY src src
+
+# install python dependencies and build project
+RUN poetry install --no-dev --no-interaction --no-ansi -v

--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@ Import DMAP data into a PostgreSQL database
 * Install ASDF ([installation guide](https://asdf-vm.com/guide/getting-started.html))
 * run `asdf install` to install tools via asdf
 * run `poetry install` to install python dependencies
+* run `cp .env.template .env` and fill out any missing environment variables
+* run `docker-compose build` to build the docker images for local testing
+    * run `docker-compose up dmap_local_rds` to stand up a local postgres db
+        * this imnage could be used when running pytest
+    * run `docker-compose up dmap_importer` to run the importer application

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+
+services:
+  dmap_local_rds:
+    container_name: dmap_local_rds 
+    image: postgres:15.4
+    env_file: .env
+    environment:
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - "5432:5432"
+    command: [ "postgres", "-c", "log_statement=all" ]
+
+  dmap_import:
+    container_name: dmap_import
+    env_file: .env
+    build:
+      context: .
+    depends_on:
+      - dmap_local_rds 
+    working_dir: /dmap_import 
+    command: ["poetry", "run", "start"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ authors = [
     "Ryan Rymarczyk <rrymarczyk@mbta.com>",
     "Mike Zappitello <mzappitello@mbta.com>"
 ]
-readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.12"


### PR DESCRIPTION
Docker Image is based off a py3.12 base image. It installs a postgres driver, an aws rds cert (via curl), and poetry. Then it copies the pyproject toml file and the py source code and builds it.

Docker Compose file uses this docker image and a postgres15.4 image to stand up the application for local testing.

.env.template file contains all the evn variables that need to be defined to run locally.

update readme with more dev steps to get the docker images up and running.