### PR TITLE
FIX: Update cert bundle for RDS connection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ RUN apt-get update
 RUN apt-get install -y libpq-dev gcc curl gzip postgresql-client
 
 # Fetch Amazon RDS certificate chain
-RUN curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem -o /usr/local/share/amazon-certs.pem
-RUN echo "d464378fbb8b981d2b28a1deafffd0113554e6adfb34535134f411bf3c689e73 /usr/local/share/amazon-certs.pem" | sha256sum -c -
+RUN curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -o /usr/local/share/amazon-certs.pem
 RUN chmod a=r /usr/local/share/amazon-certs.pem
 
 # Install poetry


### PR DESCRIPTION
RDS Connection requires `rds-ca-ecc384-g1` contained in AWS Global cert bundle