### PR TITLE
FEAT Add a new deployment workflow for prod

### DIFF
--- a/.github/workflows/deploy_to_prod.yaml
+++ b/.github/workflows/deploy_to_prod.yaml
@@ -1,0 +1,21 @@
+name: Deploy to Prod Environment
+
+on:
+  # deploy when version tags are pushed
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+	
+    
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/deploy
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          docker-repo: ${{ secrets.DOCKER_URI }}
+          env-name: prod 


### PR DESCRIPTION
This deployment will be triggered when new version tags are pushed up to origin or via a manual dispatch. It follows the same actions as the staging deployment, but with the prod environment variable.