### PR TITLE
FEAT: Check for Parallel ECS Tasks

### DIFF
--- a/src/dmap_import/pipeline.py
+++ b/src/dmap_import/pipeline.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from dmap_import.api_copy_job import run_api_copy
 from dmap_import.api_job_list import produce_job_list
-from dmap_import.util_aws import check_for_parallel_tasks
+from dmap_import.util_aws import running_in_aws, check_for_parallel_tasks
 from dmap_import.util_logging import ProcessLogger
 from dmap_import.util_rds import alembic_upgrade_to_head
 
@@ -11,6 +11,7 @@ from dmap_import.util_rds import alembic_upgrade_to_head
 def validate_environment(
     required_variables: List[str],
     private_variables: Optional[List[str]] = None,
+    aws_variables: Optional[List[str]] = None,
     validate_db: bool = False,
 ) -> None:
     """
@@ -25,6 +26,9 @@ def validate_environment(
 
     # every pipeline needs a service name for logging
     required_variables.append("SERVICE_NAME")
+
+    if aws_variables and running_in_aws():
+        required_variables += aws_variables
 
     # add required database variables
     if validate_db:
@@ -106,11 +110,14 @@ def main() -> None:
             "CONTROLLED_KEY",
             "PUBLIC_KEY",
             "DMAP_BASE_URL",
-            "ENVIRONMENT",
         ],
         private_variables=[
             "CONTROLLED_KEY",
             "PUBLIC_KEY",
+        ],
+        aws_variables=[
+            "ECS_CLUSTER",
+            "ECS_TASK_GROUP"
         ],
         validate_db=True,
     )

--- a/src/dmap_import/pipeline.py
+++ b/src/dmap_import/pipeline.py
@@ -1,6 +1,8 @@
 import os
 from typing import List, Optional
 
+import boto3
+
 from dmap_import.util_rds import alembic_upgrade_to_head
 from dmap_import.api_job_list import produce_job_list
 from dmap_import.api_copy_job import run_api_copy
@@ -65,6 +67,38 @@ def validate_environment(
     process_logger.log_complete()
 
 
+def check_for_parallel_tasks() -> None:
+    """
+    Check that that this task is not already running on ECS
+    """
+    process_logger = ProcessLogger("check_for_tasks")
+    process_logger.log_start()
+
+    client = boto3.client("ecs")
+    dmap_ecs_cluster = "dmap-import"
+    environment_name = os.environ["ENVIRONMENT"]
+
+    # get all of the tasks running on the cluster
+    task_arns = client.list_tasks(cluster=dmap_ecs_cluster)["taskArns"]
+
+    # if tasks are running on the cluster, get their descriptions and check to
+    # see if any match the group for this task.
+    #
+    # if the group matches, raise an exception that will terminate the process
+    if task_arns:
+        running_tasks = client.describe_tasks(
+            cluster=dmap_ecs_cluster, tasks=task_arns
+        )["tasks"]
+
+        for task in running_tasks:
+            if f"family:dmap-import-{environment_name}" == task["group"]:
+                exception = Exception("Multiple Tasks Running")
+                process_logger.log_failure(exception)
+                raise exception
+
+    process_logger.log_complete()
+
+
 def start() -> None:
     """
     Upgrade DB and run api jobs.
@@ -105,6 +139,7 @@ def main() -> None:
             "CONTROLLED_KEY",
             "PUBLIC_KEY",
             "DMAP_BASE_URL",
+            "ENVIRONMENT",
         ],
         private_variables=[
             "CONTROLLED_KEY",
@@ -112,6 +147,8 @@ def main() -> None:
         ],
         validate_db=True,
     )
+
+    check_for_parallel_tasks()
 
     start()
 

--- a/src/dmap_import/pipeline.py
+++ b/src/dmap_import/pipeline.py
@@ -115,10 +115,7 @@ def main() -> None:
             "CONTROLLED_KEY",
             "PUBLIC_KEY",
         ],
-        aws_variables=[
-            "ECS_CLUSTER",
-            "ECS_TASK_GROUP"
-        ],
+        aws_variables=["ECS_CLUSTER", "ECS_TASK_GROUP"],
         validate_db=True,
     )
 

--- a/src/dmap_import/pipeline.py
+++ b/src/dmap_import/pipeline.py
@@ -1,12 +1,11 @@
 import os
 from typing import List, Optional
 
-import boto3
-
-from dmap_import.util_rds import alembic_upgrade_to_head
-from dmap_import.api_job_list import produce_job_list
 from dmap_import.api_copy_job import run_api_copy
+from dmap_import.api_job_list import produce_job_list
+from dmap_import.util_aws import check_for_parallel_tasks
 from dmap_import.util_logging import ProcessLogger
+from dmap_import.util_rds import alembic_upgrade_to_head
 
 
 def validate_environment(
@@ -63,38 +62,6 @@ def validate_environment(
         )
         process_logger.log_failure(exception)
         raise exception
-
-    process_logger.log_complete()
-
-
-def check_for_parallel_tasks() -> None:
-    """
-    Check that that this task is not already running on ECS
-    """
-    process_logger = ProcessLogger("check_for_tasks")
-    process_logger.log_start()
-
-    client = boto3.client("ecs")
-    dmap_ecs_cluster = "dmap-import"
-    environment_name = os.environ["ENVIRONMENT"]
-
-    # get all of the tasks running on the cluster
-    task_arns = client.list_tasks(cluster=dmap_ecs_cluster)["taskArns"]
-
-    # if tasks are running on the cluster, get their descriptions and check to
-    # see if any match the group for this task.
-    #
-    # if the group matches, raise an exception that will terminate the process
-    if task_arns:
-        running_tasks = client.describe_tasks(
-            cluster=dmap_ecs_cluster, tasks=task_arns
-        )["tasks"]
-
-        for task in running_tasks:
-            if f"family:dmap-import-{environment_name}" == task["group"]:
-                exception = Exception("Multiple Tasks Running")
-                process_logger.log_failure(exception)
-                raise exception
 
     process_logger.log_complete()
 

--- a/src/dmap_import/util_aws.py
+++ b/src/dmap_import/util_aws.py
@@ -1,0 +1,46 @@
+import os
+import boto3
+
+from dmap_import.util_logging import ProcessLogger
+
+
+def running_in_aws() -> bool:
+    """
+    return True if running on aws, else False
+    """
+    return bool(os.getenv("AWS_DEFAULT_REGION"))
+
+
+def check_for_parallel_tasks() -> None:
+    """
+    Check that that this task is not already running on ECS
+    """
+    if not running_in_aws():
+        return
+
+    process_logger = ProcessLogger("check_for_tasks")
+    process_logger.log_start()
+
+    client = boto3.client("ecs")
+    dmap_ecs_cluster = "dmap-import"
+    environment_name = os.environ["ENVIRONMENT"]
+
+    # get all of the tasks running on the cluster
+    task_arns = client.list_tasks(cluster=dmap_ecs_cluster)["taskArns"]
+
+    # if tasks are running on the cluster, get their descriptions and check to
+    # see if any match the group for this task.
+    #
+    # if the group matches, raise an exception that will terminate the process
+    if task_arns:
+        running_tasks = client.describe_tasks(
+            cluster=dmap_ecs_cluster, tasks=task_arns
+        )["tasks"]
+
+        for task in running_tasks:
+            if f"family:dmap-import-{environment_name}" == task["group"]:
+                exception = Exception("Multiple Tasks Running")
+                process_logger.log_failure(exception)
+                raise exception
+
+    process_logger.log_complete()

--- a/src/dmap_import/util_rds.py
+++ b/src/dmap_import/util_rds.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import DeclarativeBase
 from alembic.config import Config
 from alembic import command
 
+from dmap_import.util_aws import running_in_aws
 from dmap_import.util_logging import ProcessLogger
 
 
@@ -25,13 +26,6 @@ def running_in_docker() -> bool:
         or os.path.isfile(path)
         and any("docker" in line for line in open(path, encoding="UTF-8"))
     )
-
-
-def running_in_aws() -> bool:
-    """
-    return True if running on aws, else False
-    """
-    return bool(os.getenv("AWS_DEFAULT_REGION"))
 
 
 def get_db_host() -> str:


### PR DESCRIPTION
Although unlikely because of the configuration in our infrastructure, the dmap import task could be ran more than once in parallel. If they were both writing to the RDS at the same time, chaotic behavior could result.

To prevent this, check for parallel tasks before starting the main process using a boto3 ecs client.