### PR TITLE
feat: add reference_notes column

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
+
 # dmap-import
 Import DMAP data into a PostgreSQL database
 
-## Dev Setup
-* Install ASDF ([installation guide](https://asdf-vm.com/guide/getting-started.html))
+## Dev Setup (Mac)
+
+* Install ASDF, Python3, Postgres
+```sh
+brew install asdf
+brew install python3
+brew install postgresql
+```
 * run `asdf install` to install tools via asdf
 * run `poetry install` to install python dependencies
 * run `cp .env.template .env` and fill out any missing environment variables
@@ -24,3 +31,11 @@ Import DMAP data into a PostgreSQL database
     * `poetry run mypy .`
     * `poetry run pylint src tests`
 6. Run tests, `poetry run pytest`.
+
+### Alembic
+
+To create new migration:
+```sh
+alembic revision -m "adding a new column"
+# [optional] rename generated file so as to sort migrations by name by prepending '0xx_'
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 
 services:
   dmap_local_rds:

--- a/src/alembic/versions/003_fb033ef6de1b_add_reference_notes_column.py
+++ b/src/alembic/versions/003_fb033ef6de1b_add_reference_notes_column.py
@@ -1,0 +1,35 @@
+"""add reference_notes column
+
+Revision ID: fb033ef6de1b
+Revises: 0d3bf1348c58
+Create Date: 2024-07-09 09:03:11.190561
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "fb033ef6de1b"
+down_revision: Union[str, None] = "0d3bf1348c58"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "use_transaction_longitudinal",
+        sa.Column("reference_notes", sa.String()),
+    )
+    op.add_column(
+        "use_transaction_location", sa.Column("reference_notes", sa.String())
+    )
+    op.add_column("sale_transaction", sa.Column("reference_notes", sa.String()))
+
+
+def downgrade() -> None:
+    op.drop_column("use_transaction_longitudinal", "reference_notes")
+    op.drop_column("use_transaction_location", "reference_notes")
+    op.drop_column("sale_transaction", "reference_notes")

--- a/src/dmap_import/schemas/sale_transaction.py
+++ b/src/dmap_import/schemas/sale_transaction.py
@@ -183,3 +183,4 @@ class SaleTransaction(SqlBase):
     _exported_dtm = sa.Column(sa.DateTime, nullable=True)
     promotion_id = sa.Column(sa.String(), nullable=True)
     reference = sa.Column(sa.String(), nullable=True)
+    reference_notes = sa.Column(sa.String(), nullable=True)

--- a/src/dmap_import/schemas/use_transaction_location.py
+++ b/src/dmap_import/schemas/use_transaction_location.py
@@ -158,3 +158,4 @@ class UseTransactionalLocation(SqlBase):
     _exported_dtm = sa.Column(sa.DateTime, nullable=True)
     promotion_id = sa.Column(sa.String(), nullable=True)
     reference = sa.Column(sa.String(), nullable=True)
+    reference_notes = sa.Column(sa.String(), nullable=True)

--- a/src/dmap_import/schemas/use_transaction_longitudinal.py
+++ b/src/dmap_import/schemas/use_transaction_longitudinal.py
@@ -156,3 +156,4 @@ class UseTransactionalLongitudinal(SqlBase):
     _exported_dtm = sa.Column(sa.DateTime, nullable=True)
     promotion_id = sa.Column(sa.String(), nullable=True)
     reference = sa.Column(sa.String(), nullable=True)
+    reference_notes = sa.Column(sa.String(), nullable=True)


### PR DESCRIPTION
Cubic has renamed the `reference` column to `reference_notes`. Since this work was deployed, I need to have a new migration to support this new column.