### PR TITLE
FIX: Ignore Oridnal column in schema files

### DIFF
--- a/src/cubic_loader/qlik/ods_qlik.py
+++ b/src/cubic_loader/qlik/ods_qlik.py
@@ -38,7 +38,6 @@ from cubic_loader.utils.logger import ProcessLogger
 
 DFM_COLUMN_SCHEMA = pl.Schema(
     {
-        "ordinal": pl.Int64(),
         "name": pl.String(),
         "type": pl.String(),
         "length": pl.Int64(),


### PR DESCRIPTION
We don't care about changes in ordinal value, this can be ignore. Including it is causing failures to load files for ods-qlik process. 