### PR TITLE
FEAT: Reset ODS tables for new QLIK Snapshot

### DIFF
--- a/src/cubic_loader/qlik/rds_utils.py
+++ b/src/cubic_loader/qlik/rds_utils.py
@@ -143,7 +143,7 @@ def drop_table(table_name: str) -> str:
     """
     DROP table from RDS
     """
-    return f"DROP TABLE IF EXISTS {ODS_SCHEMA}.{table_name};"
+    return f"DROP TABLE IF EXISTS {ODS_SCHEMA}.{table_name} CASCADE;"
 
 
 def add_columns_to_table(new_columns: List[DFMSchemaFields], fact_table: str) -> str:


### PR DESCRIPTION
The original implementation of the ODS-QLIK RDS loader assumed that new snapshots would not be created. An assert check made sure that this condition stopped any loading operation if a new snapshot was detected.

This change loads new QLIK snapshots by totally wiping out the existing history and fact tables and loading the newest snapshot that is found. 

With this implementation all transaction history will be lost any time cubic restarts the QLIK replication process. 

This change requires that the application ECS be given DELETE permission for the application status files on S3. 

Devops PR: https://github.com/mbta/devops/pull/2170