### PR TITLE
FEAT: run dmap-import task via GHA

### DIFF
--- a/.github/workflows/run-task.yaml
+++ b/.github/workflows/run-task.yaml
@@ -1,0 +1,27 @@
+name: Run Task
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment
+        type: choice
+        options:
+          - staging
+          - prod
+
+jobs:
+  run_task:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@v3
+      - name: Run Task Action
+        uses: mbta/actions/ecs-run-task@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          cluster: 'dmap-import'
+          service: dmap-import-${{ inputs.environment }}


### PR DESCRIPTION
New Github action for manually triggering run of `dmap-import` task. 

Relies on a couple other PRs to be implemented: 
https://github.com/mbta/actions/pull/62
https://github.com/mbta/devops/pull/2261