### PR TITLE
[dmap-import] FEAT: Log error when DMAP API file contains no records.

### DIFF
--- a/src/cubic_loader/dmap/api_copy_job.py
+++ b/src/cubic_loader/dmap/api_copy_job.py
@@ -194,10 +194,17 @@ def run_api_copy(url: str, destination_table: Any) -> None:
 
             update_api_metadata_table(url, result, db_manager)
 
-            api_result_log.log_complete(
+            api_result_log.add_metadata(
                 db_records_deleted=delete_result.rowcount,
                 db_records_added=update_result.rowcount,
             )
+
+            if update_result.rowcount > 0:
+                api_result_log.log_complete()
+            else:
+                api_result_log.log_failure(
+                    exception=AssertionError(f"dataset_id: {result["dataset_id"]} contains no records.")
+                )
 
         except Exception as exception:
             api_result_log.log_failure(exception)


### PR DESCRIPTION
The change logs an Error/Exception if dmap-import API download contains no records. 

Cubic should not be publishing API downloads without records. This change will propagate notifications of empty dmap datasets to splunk alerts. 

Asana Task: https://app.asana.com/0/1203883924584572/1208782928208814