### PR TITLE
FIX: Drop Tables for migration / Dynamic JOIN operation

### DIFF
--- a/src/alembic/versions/007_96837b10c106_reset_qlik_null_key_tables.py
+++ b/src/alembic/versions/007_96837b10c106_reset_qlik_null_key_tables.py
@@ -9,6 +9,8 @@ Create Date: 2021-01-07 19:42:12.287594
 import os
 from typing import Sequence, Union
 
+from alembic import op
+
 from cubic_loader.utils.aws import s3_delete_object
 from cubic_loader.utils.remote_locations import ODS_STATUS
 
@@ -24,6 +26,10 @@ def upgrade() -> None:
     # This will force a reset/re-load for these tables in dmap-import DB
     s3_delete_object(os.path.join(ODS_STATUS, "EDW.PAYMENT_SUMMARY.json"))
     s3_delete_object(os.path.join(ODS_STATUS, "EDW.MEMBER_DIMENSION.json"))
+    op.drop_table("edw_payment_summary", schema="ods")
+    op.drop_table("edw_payment_summary_history", schema="ods")
+    op.drop_table("edw_member_dimension", schema="ods")
+    op.drop_table("edw_member_dimension_history", schema="ods")
 
 
 def downgrade() -> None:

--- a/src/cubic_loader/qlik/rds_utils.py
+++ b/src/cubic_loader/qlik/rds_utils.py
@@ -1,5 +1,6 @@
 from typing import List
 from typing import Optional
+from typing import Tuple
 from datetime import date
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
@@ -181,23 +182,23 @@ def add_columns_to_table(new_columns: List[DFMSchemaFields], schema_and_table: s
     return " ".join(alter_strings)
 
 
-def bulk_delete_from_temp(schema_and_table: str, key_columns: List[str]) -> str:
+def bulk_delete_from_temp(schema_and_table: str, op_and_keys: List[Tuple[str, str]]) -> str:
     """
     create query to DELETE records from table based on key columns
     """
     tmp_table = f"{schema_and_table}_load"
-    where_clause = " AND ".join([f"{schema_and_table}.{t} IS NOT DISTINCT FROM {tmp_table}.{t}" for t in key_columns])
-    delete_query = f"DELETE FROM {schema_and_table} " f"USING {tmp_table} " f"WHERE {where_clause};"
+    where_clause = " AND ".join([f"{schema_and_table}.{t} {op} {tmp_table}.{t}" for op, t in op_and_keys])
+    delete_query = f"DELETE FROM {schema_and_table} USING {tmp_table} WHERE {where_clause};"
 
     return delete_query
 
 
-def bulk_update_from_temp(schema_and_table: str, update_column: str, key_columns: List[str]) -> str:
+def bulk_update_from_temp(schema_and_table: str, update_column: str, op_and_keys: List[Tuple[str, str]]) -> str:
     """
     create query to UPDATE records from table based on key columns
     """
     tmp_table = f"{schema_and_table}_load"
-    where_clause = " AND ".join([f"{schema_and_table}.{t} IS NOT DISTINCT FROM {tmp_table}.{t}" for t in key_columns])
+    where_clause = " AND ".join([f"{schema_and_table}.{t} {op} {tmp_table}.{t}" for op, t in op_and_keys])
     update_query = (
         f"UPDATE {schema_and_table} SET {update_column}={tmp_table}.{update_column} "
         f"FROM {tmp_table} WHERE {where_clause};"


### PR DESCRIPTION
Two changes in this PR:

1. Explicitly drop these tables when deleting the status files to force full table reset. 
2. Dynamically select join operation (`=` or `IS NOT DISTINCT FROM`) in update and delete operations based on presence of NULL values in key columns. 

Change 2 was made because using `IS NOT DISTINCT FROM` has huge implications on query performance so it should only be used where absolutely necessary. 