### PR TITLE
FIX: Staging failing on 2d6f7140c642 migration

### DIFF
--- a/src/alembic/versions/008_2d6f7140c642_wc_700_comp_a_b.py
+++ b/src/alembic/versions/008_2d6f7140c642_wc_700_comp_a_b.py
@@ -6,6 +6,7 @@ Create Date: 2021-01-10 09:49:12.274894
 
 """
 
+import logging
 from typing import Sequence, Union
 
 from alembic import op
@@ -53,8 +54,6 @@ def upgrade() -> None:
             ,settlement_day_key desc
         ;
     """
-    op.execute(comp_a_view)
-
     comp_b_view = """
         CREATE OR REPLACE VIEW ods.wc700_comp_b 
         AS
@@ -86,7 +85,11 @@ def upgrade() -> None:
             ,settlement_day_key desc
         ;
     """
-    op.execute(comp_b_view)
+    try:
+        op.execute(comp_a_view)
+        op.execute(comp_b_view)
+    except Exception as exception:
+        logging.exception(exception)
 
 
 def downgrade() -> None:


### PR DESCRIPTION
Staging is failing on this migration because ODS tables do not exist.

This was already successfully deployed to PROD. 