### PR TITLE
FIX: Drop COMP-A View

### DIFF
--- a/src/alembic/versions/009_f2c5a52c7149_fix_wc700_comp_a.py
+++ b/src/alembic/versions/009_f2c5a52c7149_fix_wc700_comp_a.py
@@ -54,6 +54,7 @@ def upgrade() -> None:
         ;
     """
     try:
+        op.execute("DROP VIEW IF EXISTS ods.wc700_comp_a;")
         op.execute(comp_a_view)
     except Exception as exception:
         logging.exception(exception)


### PR DESCRIPTION
WC700 Comp-A View must be dropped before migration. 