### PR TITLE
FIX[dmap-import]: Change pk_id to BigInteger for large tables.

### DIFF
--- a/src/alembic/versions/011_bf94c2890bc9_pk_id_to_bigint.py
+++ b/src/alembic/versions/011_bf94c2890bc9_pk_id_to_bigint.py
@@ -14,7 +14,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "bf94c2890bc9"
-down_revision: Union[str, None] = 'ab250e2a0b0d'
+down_revision: Union[str, None] = "ab250e2a0b0d"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/alembic/versions/011_bf94c2890bc9_pk_id_to_bigint.py
+++ b/src/alembic/versions/011_bf94c2890bc9_pk_id_to_bigint.py
@@ -1,0 +1,55 @@
+"""pk_id to bigint
+
+Revision ID: bf94c2890bc9
+Revises: ab250e2a0b0d
+Create Date: 2025-02-03 10:14:44.209868
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "bf94c2890bc9"
+down_revision: Union[str, None] = 'ab250e2a0b0d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "device_event",
+        "pk_id",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "sale_transaction",
+        "pk_id",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "use_transaction_location",
+        "pk_id",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "use_transaction_longitudinal",
+        "pk_id",
+        existing_type=sa.INTEGER(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    # Can not migrate from INT to BIGINT without losing data.
+    pass

--- a/src/cubic_loader/dmap/schemas/device_event.py
+++ b/src/cubic_loader/dmap/schemas/device_event.py
@@ -9,7 +9,7 @@ class DeviceEvents(SqlBase):
 
     __tablename__ = "device_event"
 
-    pk_id = sa.Column(sa.Integer, primary_key=True)
+    pk_id = sa.Column(sa.BigInteger, primary_key=True)
     dataset_id = sa.Column(sa.String(), nullable=True, index=True)
     id = sa.Column(sa.String(), nullable=True)
     inserted_dtm = sa.Column(sa.DateTime, nullable=True)

--- a/src/cubic_loader/dmap/schemas/sale_transaction.py
+++ b/src/cubic_loader/dmap/schemas/sale_transaction.py
@@ -10,7 +10,7 @@ class SaleTransaction(SqlBase):
 
     __tablename__ = "sale_transaction"
 
-    pk_id = sa.Column(sa.Integer, primary_key=True)
+    pk_id = sa.Column(sa.BigInteger, primary_key=True)
     dataset_id = sa.Column(sa.String(), nullable=True, index=True)
     id = sa.Column(sa.String(), nullable=True)
     inserted_dtm = sa.Column(sa.DateTime, nullable=True)

--- a/src/cubic_loader/dmap/schemas/use_transaction_location.py
+++ b/src/cubic_loader/dmap/schemas/use_transaction_location.py
@@ -10,7 +10,7 @@ class UseTransactionalLocation(SqlBase):
 
     __tablename__ = "use_transaction_location"
 
-    pk_id = sa.Column(sa.Integer, primary_key=True)
+    pk_id = sa.Column(sa.BigInteger, primary_key=True)
     dataset_id = sa.Column(sa.String(), nullable=True, index=True)
     id = sa.Column(sa.String(), nullable=True)
     inserted_dtm = sa.Column(sa.DateTime, nullable=True)

--- a/src/cubic_loader/dmap/schemas/use_transaction_longitudinal.py
+++ b/src/cubic_loader/dmap/schemas/use_transaction_longitudinal.py
@@ -10,7 +10,7 @@ class UseTransactionalLongitudinal(SqlBase):
 
     __tablename__ = "use_transaction_longitudinal"
 
-    pk_id = sa.Column(sa.Integer, primary_key=True)
+    pk_id = sa.Column(sa.BigInteger, primary_key=True)
     dataset_id = sa.Column(sa.String(), nullable=True, index=True)
     id = sa.Column(sa.String(), nullable=True)
     inserted_dtm = sa.Column(sa.DateTime, nullable=True)


### PR DESCRIPTION
Prod environment throwing errors because `pk_id` column hit the maximum Integer value.

```
nextval: reached maximum value of sequence "device_event_pk_id_seq" (2147483647)
```

This changes updates the `pk_id` column for large dmap tables to use BigInteger, with much larger maximum value. 

This issues does not impact ODS tables, as all of the ODS field types are dictated by QLIK dfm files. 