### PR TITLE
FEAT: Use odin archive partition as ods_qlik Job Source

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,1 @@
-use asdf
-
 dotenv

--- a/src/cubic_loader/utils/remote_locations.py
+++ b/src/cubic_loader/utils/remote_locations.py
@@ -8,6 +8,7 @@ S3_ERROR = os.getenv("ERROR_BUCKET", "unset_ERROR_BUCKET")
 QLIK = "cubic/ods_qlik"
 ODS_SCHEMA = "ods"
 ODS_STATUS = os.path.join(S3_ARCHIVE, QLIK, "rds_load_status")
+ODIN_PROCESSED = "odin/archive/cubic_qlik/processed"
 
 # db constants
 DB_HOST = os.getenv("DB_HOST", "unset_DB_HOST")


### PR DESCRIPTION
We will be turning `odin` on for PROD shortly, so the `dmap-import` Qlik job will need to read from the ODIN Archive partition for each ODS table. 