### PR TITLE
temp: Revert back to reading from QLIK archive location 

### DIFF
--- a/src/cubic_loader/qlik/ods_qlik.py
+++ b/src/cubic_loader/qlik/ods_qlik.py
@@ -56,7 +56,7 @@ from cubic_loader.utils.logger import ProcessLogger
 
 def get_snapshot_dfms(table: str) -> List[DFMDetails]:
     """find all available snapshot dfm files for a qlik table from Archive bucket"""
-    prefix = os.path.join(ODIN_PROCESSED, QLIK, f"{table}/")
+    prefix = os.path.join(QLIK, f"{table}/")
     archive_dfms = s3_list_objects(S3_ARCHIVE, prefix, in_filter=".dfm")
 
     found_snapshots = []
@@ -80,6 +80,12 @@ def get_cdc_gz_csvs(etl_status: TableStatus, table: str) -> List[str]:
     snapshot_prefix = f"{table_prefix}snapshot={etl_status.current_snapshot_ts}/"
 
     cdc_csvs = s3_list_cdc_gz_objects(S3_ARCHIVE, snapshot_prefix, min_ts=etl_status.last_cdc_ts)
+
+    # Temp read from qlik archive while ODIN Prod is down.
+    table_prefix = os.path.join(QLIK, f"{table}__ct/")
+    snapshot_prefix = f"{table_prefix}snapshot={etl_status.current_snapshot_ts}/"
+
+    cdc_csvs += s3_list_cdc_gz_objects(S3_ARCHIVE, snapshot_prefix, min_ts=etl_status.last_cdc_ts)
 
     return sorted(cdc_csvs, key=lambda l: re_get_first(l, RE_CDC_TS))
 


### PR DESCRIPTION
Odin PROD Cubic ODS-Qlik processing has been temporarily suspended while a few qlik related issues are resolved. 

This change will read files from old Qlik Archive location temporarily. 