### PR TITLE
FIX: Catch CubicODSQlik Creation Error

### DIFF
--- a/src/cubic_loader/pipeline.py
+++ b/src/cubic_loader/pipeline.py
@@ -52,8 +52,13 @@ def start_qlik_load() -> None:
     db = DatabaseManager()
 
     for cubic_table in CUBIC_ODS_TABLES:
-        qlik_table = CubicODSQlik(cubic_table, db)
-        qlik_table.run_etl()
+        try:
+            log = ProcessLogger("CubicODSQlik", cubic_table=cubic_table)
+            qlik_table = CubicODSQlik(cubic_table, db)
+            qlik_table.run_etl()
+            log.log_complete()
+        except Exception as exception:
+            log.log_failure(exception)
 
     db.refresh_mat_views(ODS_SCHEMA)
 

--- a/src/cubic_loader/qlik/ods_qlik.py
+++ b/src/cubic_loader/qlik/ods_qlik.py
@@ -63,6 +63,11 @@ def get_snapshot_dfms(table: str) -> List[DFMDetails]:
     for dfm in archive_dfms:
         found_snapshots.append(DFMDetails(path=dfm, ts=re_get_first(dfm, RE_SNAPSHOT_TS)))
 
+    prefix = os.path.join(ODIN_PROCESSED, QLIK, f"{table}/")
+    odin_archive_dfms = s3_list_objects(S3_ARCHIVE, prefix, in_filter=".dfm")
+    for dfm in odin_archive_dfms:
+        found_snapshots.append(DFMDetails(path=dfm, ts=re_get_first(dfm, RE_SNAPSHOT_TS)))
+
     assert len(found_snapshots) > 0
 
     return sorted(found_snapshots, key=attrgetter("ts"))


### PR DESCRIPTION
Load snapshot paths from ODIN processed and catch CubicODSQlik Class creation errors.