### PR TITLE
FIX: Reduce size of cdc load folder size

### DIFF
--- a/src/cubic_loader/qlik/ods_qlik.py
+++ b/src/cubic_loader/qlik/ods_qlik.py
@@ -433,7 +433,7 @@ class CubicODSQlik:
                     pass
 
                 # load any cdc hash folder greater than max_folder_bytes
-                self.cdc_check_load_folders(tmp_dir, max_folder_bytes=60_000_000)
+                self.cdc_check_load_folders(tmp_dir, max_folder_bytes=30_000_000)
 
             # load all remaining cdc hash folders
             self.cdc_check_load_folders(tmp_dir)

--- a/src/cubic_loader/qlik/ods_qlik.py
+++ b/src/cubic_loader/qlik/ods_qlik.py
@@ -20,7 +20,6 @@ from cubic_loader.utils.aws import s3_object_exists
 from cubic_loader.utils.aws import s3_split_object_path
 from cubic_loader.utils.aws import s3_upload_file
 from cubic_loader.utils.aws import s3_delete_object
-from cubic_loader.utils.aws import s3_download_object
 from cubic_loader.utils.remote_locations import S3_ARCHIVE
 from cubic_loader.utils.remote_locations import QLIK
 from cubic_loader.utils.remote_locations import ODS_STATUS
@@ -108,7 +107,7 @@ def thread_save_csv_file(args: Tuple[str, str]) -> None:
     logger = ProcessLogger("download_cdc_file", csv_object=csv_object)
 
     try:
-        csv_local_file = csv_object.replace("s3://", "").replace("/", "|").replace(".csv.gz",".csv")
+        csv_local_file = csv_object.replace("s3://", "").replace("/", "|").replace(".csv.gz", ".csv")
         csv_local_path = os.path.join(tmp_dir, csv_local_file)
         with gzip.open(s3_get_object(csv_object), "rb") as r_bytes:
             with open(csv_local_path, mode="wb") as w_bytes:
@@ -436,7 +435,7 @@ class CubicODSQlik:
                     pass
 
                 # load any cdc hash folder greater than max_folder_bytes
-                self.cdc_check_load_folders(tmp_dir, max_folder_bytes=256*1024*1024)
+                self.cdc_check_load_folders(tmp_dir, max_folder_bytes=256 * 1024 * 1024)
 
             # load all remaining cdc hash folders
             self.cdc_check_load_folders(tmp_dir)

--- a/src/cubic_loader/qlik/utils.py
+++ b/src/cubic_loader/qlik/utils.py
@@ -1,6 +1,5 @@
 import os
 import re
-import gzip
 import json
 from typing import NamedTuple
 from typing import TypedDict

--- a/src/cubic_loader/qlik/utils.py
+++ b/src/cubic_loader/qlik/utils.py
@@ -194,7 +194,7 @@ def merge_cdc_csv_gz_files(tmp_dir: str) -> str:
     with open(merge_file, "wb") as fout:
         for cdc_path in cdc_paths:
             max_ts = max(max_ts, re_get_first(cdc_path, RE_CDC_TS))
-            with gzip.open(cdc_path, "rb") as f:
+            with open(cdc_path, "rb") as f:
                 if fout.tell() > 0:
                     next(f)
                 fout.write(f.read())


### PR DESCRIPTION
~~dmap-import ECS is dying without any logging output, presumable from OOM errors when loading EDW.CCH_AFC_TRANSACTION change files.~~

~~It's unclear why this would begin happening all of a sudden, as the current check limits the folder size to 60MB. This change reduces the folder size limit to 30MB to see if the CCH_AFC_TRANSACTION table change files can be loaded~~.

Scratch that, after literal minutes of reflection. I think this issue might be caused by a csv.gz zip bomb blowing up the ECS memory. 

When loading CDC files the Qlik process keeps track of the total `csv.gz` file sizes in a folder and processes the folder when they reach a limit (~60mb). However if this is extremely sparse data, the csv.gz compression could be causing an in-memory zip bomb when the highly compressed, and sparse data, is realized into a dataframe. 

This change updates the process to save these files as un-compressed .csv and monitor the folder size with a higher threshold of 256MB. This should avoid the zip bomb issue and allow any table to be loaded within  the memory constrains of the ECS. 
