### PR TITLE
FIX: Add PR Template text for Qlik Jobs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+<!-- 
+Any changes made to `src/cubic_loader/qlik/ods_tables.py` need to also be added as `odin` (github.com/mbta/odin) qlik tables.
+
+Qlik tables, being loaded by this application, are configured to pull from from the `odin` archive location. Failure to also add tables to `odin` will result in the table data not being loaded into the dmap-import database.
+ -->
+
+<!-- Link to relevant Asana task; remove if not applicable -->
+Asana task: [ASANA_TASK_NAME](ASANA_TASK_URL)


### PR DESCRIPTION
This change adds a PR template to remind and PR creators that Qlik tables need to remain in-sync between this application and Odin.