### PR TITLE
fix: run DB migrations on staging

### DIFF
--- a/src/alembic/versions/008_2d6f7140c642_wc_700_comp_a_b.py
+++ b/src/alembic/versions/008_2d6f7140c642_wc_700_comp_a_b.py
@@ -11,6 +11,8 @@ from typing import Sequence, Union
 
 from alembic import op
 
+from cubic_loader.utils.postgres import DatabaseManager
+
 # revision identifiers, used by Alembic.
 revision: str = "2d6f7140c642"
 down_revision: Union[str, None] = "96837b10c106"
@@ -19,6 +21,11 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    db = DatabaseManager()
+    schema_check_query = "SELECT COUNT(*) from information_schema.tables WHERE table_schema = 'ods';"
+    if db.select(schema_check_query)["count"] == 0:
+        return
+
     comp_a_view = """
         CREATE OR REPLACE VIEW ods.wc700_comp_a 
         AS

--- a/src/alembic/versions/009_f2c5a52c7149_fix_wc700_comp_a.py
+++ b/src/alembic/versions/009_f2c5a52c7149_fix_wc700_comp_a.py
@@ -11,6 +11,8 @@ from typing import Sequence, Union
 
 from alembic import op
 
+from cubic_loader.utils.postgres import DatabaseManager
+
 # revision identifiers, used by Alembic.
 revision: str = "f2c5a52c7149"
 down_revision: Union[str, None] = "2d6f7140c642"
@@ -19,6 +21,11 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    db = DatabaseManager()
+    schema_check_query = "SELECT COUNT(*) from information_schema.tables WHERE table_schema = 'ods';"
+    if db.select(schema_check_query)["count"] == 0:
+        return
+
     comp_a_view = """
         CREATE OR REPLACE VIEW ods.wc700_comp_a 
         AS

--- a/src/alembic/versions/010_ab250e2a0b0d_wc700_comp_d.py
+++ b/src/alembic/versions/010_ab250e2a0b0d_wc700_comp_d.py
@@ -11,6 +11,8 @@ from typing import Sequence, Union
 
 from alembic import op
 
+from cubic_loader.utils.postgres import DatabaseManager
+
 # revision identifiers, used by Alembic.
 revision: str = "ab250e2a0b0d"
 down_revision: Union[str, None] = "f2c5a52c7149"
@@ -19,6 +21,11 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    db = DatabaseManager()
+    schema_check_query = "SELECT COUNT(*) from information_schema.tables WHERE table_schema = 'ods';"
+    if db.select(schema_check_query)["count"] == 0:
+        return
+
     comp_d_view = """
         DROP VIEW IF EXISTS ods.wc700_comp_d;
         CREATE OR REPLACE VIEW ods.wc700_comp_d 

--- a/src/alembic/versions/012_be5284c3563e.py
+++ b/src/alembic/versions/012_be5284c3563e.py
@@ -11,6 +11,7 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 
+from cubic_loader.utils.postgres import DatabaseManager
 from cubic_loader.qlik.sql_strings.views import AD_HOC_VIEW
 from cubic_loader.qlik.sql_strings.views import COMP_A_VIEW
 from cubic_loader.qlik.sql_strings.views import COMP_B_VIEW
@@ -28,6 +29,12 @@ def upgrade() -> None:
     op.execute("ALTER SEQUENCE sale_transaction_pk_id_seq AS bigint;")
     op.execute("ALTER SEQUENCE use_transaction_location_pk_id_seq AS bigint;")
     op.execute("ALTER SEQUENCE use_transaction_longitudinal_pk_id_seq AS bigint;")
+
+    db = DatabaseManager()
+    schema_check_query = "SELECT COUNT(*) from information_schema.tables WHERE table_schema = 'ods';"
+    if db.select(schema_check_query)["count"] == 0:
+        return
+
     op.execute("CREATE INDEX idx_abp_tap_inserted ON ods.edw_abp_tap (source_inserted_dtm);")
     op.execute(AD_HOC_VIEW)
     op.execute(COMP_A_VIEW)

--- a/src/alembic/versions/013_1dc0843c9d69.py
+++ b/src/alembic/versions/013_1dc0843c9d69.py
@@ -11,6 +11,7 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 
+from cubic_loader.utils.postgres import DatabaseManager
 from cubic_loader.qlik.sql_strings.mat_views import COMP_B_ADDENDUM
 
 # revision identifiers, used by Alembic.
@@ -21,6 +22,11 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    db = DatabaseManager()
+    schema_check_query = "SELECT COUNT(*) from information_schema.tables WHERE table_schema = 'ods';"
+    if db.select(schema_check_query)["count"] == 0:
+        return
+
     op.execute(COMP_B_ADDENDUM)
 
 


### PR DESCRIPTION
This change adds checks to migrations files that will allow them to run/finish on the staging environment.

Some migrations were failing on staging because the `ods` schema has no tables on staging. This change updates the migrations that modify the `ods` schema to first check if tables exist in the `ods` schema. If no tables exist, the migration exits early

