### PR TITLE
fix: CubicODSQlik use IF NOT EXISTS for column creation

### DIFF
--- a/src/cubic_loader/qlik/rds_utils.py
+++ b/src/cubic_loader/qlik/rds_utils.py
@@ -176,7 +176,7 @@ def add_columns_to_table(new_columns: List[DFMSchemaFields], schema_and_table: s
     for column in new_columns:
         for table in tables:
             alter_strings.append(
-                f"ALTER TABLE {table} ADD {column['name']} {qlik_type_to_pg(column['type'], column['scale'], column['precision'])};"
+                f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {column['name']} {qlik_type_to_pg(column['type'], column['scale'], column['precision'])};"
             )
 
     return " ".join(alter_strings)


### PR DESCRIPTION
After Cubic back office upgrade, CubicODSQlik process is throwing error for `transaction_history` table because columns are being added that already exist in the schema. "last_schema" in status file has gotten out of sync with actual DB schema.

This change will allow ADD COLUMN command to complete and "last_schema" of status file to be updated with matching schema columns.

Asana task: https://app.asana.com/1/15492006741476/project/1208949713596462/task/1210628715406251
