### PR TITLE
feat: add wa160 view to dmap-import

### DIFF
--- a/src/alembic/versions/015_4b8117e23c8e_wa160_view.py
+++ b/src/alembic/versions/015_4b8117e23c8e_wa160_view.py
@@ -1,0 +1,33 @@
+"""wa160 view
+
+Revision ID: 4b8117e23c8e
+Revises: 140dde7b15a9
+Create Date: 2025-06-26 14:35:44.209868
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+from cubic_loader.utils.postgres import DatabaseManager
+from cubic_loader.qlik.sql_strings.views import WA160_VIEW
+
+# revision identifiers, used by Alembic.
+revision: str = "4b8117e23c8e"
+down_revision: Union[str, None] = "140dde7b15a9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    db = DatabaseManager()
+    schema_check_query = "SELECT COUNT(*) from information_schema.tables WHERE table_schema = 'ods';"
+    if db.select(schema_check_query)["count"] == 0:
+        return
+
+    op.execute(WA160_VIEW)
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS ods.wa160;")

--- a/src/cubic_loader/qlik/sql_strings/views.py
+++ b/src/cubic_loader/qlik/sql_strings/views.py
@@ -173,3 +173,81 @@ COMP_D_VIEW = """
         ,ps.settlement_day_key desc
     ;
 """
+
+WA160_VIEW = """
+    DROP VIEW IF EXISTS ods.wa160;
+    CREATE OR REPLACE VIEW ods.wa160 
+    AS
+    SELECT
+        date(posting_day_key::text) as posting_date,
+        date(settlement_day_key::text) as settlement_date,
+        date(transit_day_key::text) as transit_date,
+        date(ut.operating_day_key::text) as operating_date,
+        ut.transaction_dtm,
+        ut.source_inserted_dtm,
+        voided_dtm,
+        opd.operator_name,
+        fpd.fare_prod_name,
+        ut.transit_account_id,
+        ut.serial_nbr,
+        ut.pass_use_count,
+        coalesce(ut.pass_cost, 0)::real / 100 as pass_cost,
+        coalesce(ut.value_changed, 0)::real / 100 as value_changed,
+        coalesce(ut.booking_prepaid_value, 0)::real / 100 as booking_prepaid_value,
+        coalesce(ut.benefit_value, 0)::real / 100 as benefit_value,
+        coalesce(ut.bankcard_payment_value, 0)::real / 100 as bankcard_payment_value,
+        coalesce(ut.merchant_service_fee, 0)::real / 100 as merchant_service_fee,
+        (
+            coalesce(ut.pass_cost, 0) 
+            + coalesce(ut.value_changed, 0) 
+            + coalesce(ut.booking_prepaid_value, 0) 
+            + coalesce(ut.benefit_value, 0) 
+            + coalesce(ut.bankcard_payment_value,0) 
+            + coalesce(ut.merchant_service_fee, 0)
+        )::real / 100 as total_use_cost,
+        transaction_status_name,
+        fpuld.fare_prod_users_list_name,
+        trip_price_count,
+        ut.bus_id,
+        txnsd.txn_status_name,
+        paygo_ride_count,
+        ride_count,
+        transaction_id,
+        transfer_flag,
+        transfer_sequence_nbr,
+        tad.account_status_name,
+        dw_transaction_id,
+        ut.token_id,
+        pass_id,
+        ut.pg_card_id,
+        mtd.media_type_name,
+        purse_name,
+        txnsd.successful_use_flag,
+        ut.facility_id,
+        tap_id,
+        rtd.ride_type_name,
+        coalesce(fpd.rider_class_name, tad.rider_class_name) as rider_class_name,
+        coalesce(one_account_value, 0) as one_account_value,
+        coalesce(ut.restricted_purse_value, 0) as restricted_purse_value,
+        coalesce(ut.refundable_purse_value, 0) as refundable_purse_value,
+        coalesce(ut.uncollectible_amount, 0)::real / 100 as uncollectible_amount
+    FROM
+        ods.edw_use_transaction ut
+    LEFT JOIN
+        ods.edw_fare_product_dimension fpd on ut.fare_prod_key = fpd.fare_prod_key
+    LEFT JOIN 
+        ods.edw_operator_dimension opd on ut.operator_key = opd.operator_key
+    LEFT JOIN 
+        ods.edw_card_dimension cardd on ut.card_key = cardd.card_key
+    LEFT JOIN 
+        ods.edw_ride_type_dimension rtd on ut.ride_type_key = rtd.ride_type_key
+    LEFT JOIN 
+        ods.edw_txn_status_dimension txnsd on ut.txn_status_key = txnsd.txn_status_key
+    LEFT JOIN 
+        ods.edw_media_type_dimension mtd on ut.media_type_key = mtd.media_type_key
+    LEFT JOIN 
+        ods.edw_transit_account_dimension tad on cardd.transit_account_key = tad.transit_account_key
+    LEFT JOIN 
+        ods.edw_fare_prod_users_list_dimension fpuld on fpuld.fare_prod_users_list_key = fpd.fare_prod_users_list_key
+    ;
+"""


### PR DESCRIPTION
This change adds a view to the dmap-import db, at the request of the MBTA finance team.

The new view is the WA160 report. Several original columns of this report have been removed as they produced all NULL results.

Asana task: https://app.asana.com/1/15492006741476/project/1208949713596457/task/1210511428402701
