### PR TITLE
fix: /tmp folder mem leak fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM python:3.12-slim
 # Prevents buffering for easier container logging
 ENV PYTHONUNBUFFERED 1
 
+# Mount /tmp VOLUME for AWS mem leak bug
+RUN mkdir -p /tmp && chmod 777 /tmp
+VOLUME ["/tmp"]
+
 # Install non python dependencies
 RUN apt-get update --fix-missing
 RUN apt-get install -y libpq-dev gcc curl gzip zip unzip postgresql-client


### PR DESCRIPTION
`dmap-import` makes heavy use of /tmp folder file writing, which seems like is being reported as excessive memory usage causing the ECS to be killed.

This change deploys the "tmp folder fix" that other ECS instances have deployed to resolved this issue.

Deploy will need to be coordinated with additional infra PRs. terraform modules PR already created: https://github.com/mbta/terraform_modules/pull/259
