### PR TITLE
FIX: run CubicODSQlik in each own process

### DIFF
--- a/src/cubic_loader/qlik/ods_qlik.py
+++ b/src/cubic_loader/qlik/ods_qlik.py
@@ -121,11 +121,10 @@ class CubicODSQlik:
     used to load ODS data from S3 bucket to RDS tables
     """
 
-    def __init__(self, table: str, db: DatabaseManager, schema: str = ODS_SCHEMA):
+    def __init__(self, table: str, schema: str = ODS_SCHEMA):
         """
         :param table: Cubic ODS Table Name eg ("EDW.CARD_DIMENSION")
         """
-        self.db = db
         self.table = table
         self.status_path = os.path.join(ODS_STATUS, f"{table}.json")
         self.db_fact_table = f"{schema}.{table.replace(".", "_").lower()}"
@@ -469,6 +468,8 @@ class CubicODSQlik:
         If a new QLIK Snapshot is detected, all existing tables will be dropped and whole process will be
         reset to load NEW Snapshot
         """
+        # pylint: disable-next=attribute-defined-outside-init
+        self.db = DatabaseManager()
         logger = ProcessLogger(
             "ods_qlik_run_etl",
             table=self.db_fact_table,


### PR DESCRIPTION
Qlik process appears to be leaking memory between table runs.

This change runs each CubicODSQlik table instance in it's own process to hopefully clean up this memory leak. the DatabaseManager object can not be pickled into the process before running, so new DatabseManager must be created when each table instance runs. 
