### PR TITLE
fix: dmap fare_prod_id to string

### DIFF
--- a/src/alembic/versions/018_76a64efdbdd9_alter_fare_prod_id_varchar.py
+++ b/src/alembic/versions/018_76a64efdbdd9_alter_fare_prod_id_varchar.py
@@ -1,0 +1,30 @@
+"""alter fare_prod_id to varchar
+
+Revision ID: 76a64efdbdd9
+Revises: b6ecb4180ef0
+Create Date: 2025-08-06 10:39:30.287594
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "76a64efdbdd9"
+down_revision: Union[str, None] = "b6ecb4180ef0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column("sale_transaction", "fare_prod_id", type_=sa.String())
+    op.alter_column("use_transaction_location", "fare_prod_id", type_=sa.String())
+    op.alter_column("use_transaction_longitudinal", "fare_prod_id", type_=sa.String())
+
+
+def downgrade() -> None:
+    # NO downgrade
+    pass

--- a/src/cubic_loader/dmap/schemas/sale_transaction.py
+++ b/src/cubic_loader/dmap/schemas/sale_transaction.py
@@ -77,7 +77,7 @@ class SaleTransaction(SqlBase):
     transit_mode_name = sa.Column(sa.String(), nullable=True)
     transit_mode_desc = sa.Column(sa.String(), nullable=True)
     array_position = sa.Column(sa.BigInteger, nullable=True)
-    fare_prod_id = sa.Column(sa.BigInteger, nullable=True)
+    fare_prod_id = sa.Column(sa.String(), nullable=True)
     fare_prod_name = sa.Column(sa.String(), nullable=True)
     fare_prod_desc = sa.Column(sa.String(), nullable=True)
     fare_prod_rider_class_id = sa.Column(sa.BigInteger, nullable=True)

--- a/src/cubic_loader/dmap/schemas/use_transaction_location.py
+++ b/src/cubic_loader/dmap/schemas/use_transaction_location.py
@@ -67,7 +67,7 @@ class UseTransactionalLocation(SqlBase):
     transit_mode_name = sa.Column(sa.String(), nullable=True)
     transit_mode_desc = sa.Column(sa.String(), nullable=True)
     array_position = sa.Column(sa.String(), nullable=True)
-    fare_prod_id = sa.Column(sa.BigInteger, nullable=True)
+    fare_prod_id = sa.Column(sa.String(), nullable=True)
     fare_prod_name = sa.Column(sa.String(), nullable=True)
     fare_prod_desc = sa.Column(sa.String(), nullable=True)
     fare_prod_rider_class_id = sa.Column(sa.BigInteger, nullable=True)

--- a/src/cubic_loader/dmap/schemas/use_transaction_longitudinal.py
+++ b/src/cubic_loader/dmap/schemas/use_transaction_longitudinal.py
@@ -62,7 +62,7 @@ class UseTransactionalLongitudinal(SqlBase):
     transit_mode_name = sa.Column(sa.String(), nullable=True)
     transit_mode_desc = sa.Column(sa.String(), nullable=True)
     array_position = sa.Column(sa.String(), nullable=True)
-    fare_prod_id = sa.Column(sa.BigInteger, nullable=True)
+    fare_prod_id = sa.Column(sa.String(), nullable=True)
     fare_prod_name = sa.Column(sa.String(), nullable=True)
     fare_prod_desc = sa.Column(sa.String(), nullable=True)
     fare_prod_rider_class_id = sa.Column(sa.BigInteger, nullable=True)


### PR DESCRIPTION
Cubic has communicated that the `fare_prod_id` field in all dmap tables will be changing to a varchar/string type.

This change contains the migration required to update this field in the dmap-import DB.


Asana task: https://app.asana.com/1/15492006741476/project/1208949713596462/task/1210986298091645
