### PR TITLE
Quick fix to stop EDW.TRANSACTION_HISTORY from loading

### DIFF
--- a/src/cubic_loader/qlik/ods_tables.py
+++ b/src/cubic_loader/qlik/ods_tables.py
@@ -20,7 +20,7 @@ CUBIC_ODS_TABLES = [
     "EDW.TRIP_PAYMENT",
     "EDW.SALE_TRANSACTION",
     "EDW.PAYMENT_TYPE_DIMENSION",
-    "EDW.TRANSACTION_HISTORY",
+    # "EDW.TRANSACTION_HISTORY", # table is taking days to load, blocking other tables from loading
     "EDW.FARE_REVENUE_REPORT_SCHEDULE",  # addendum support
     # FMIS
     "EDW.FNP_GENERAL_JRNL_ACCOUNT_ENTRY",


### PR DESCRIPTION
EDW.TRANSACTION_HISTORY is taking days to load, preventing any other tables from loading

Asana task: [dmap-import: disable EDW.TRANSACTION_HISTORY table loading](https://app.asana.com/1/15492006741476/project/1210977089884035/task/1211038111230451?focus=true)
