### PR TITLE
feat: add validator_interface column to use_transaction_*

### DIFF
--- a/src/alembic/versions/019_92ab6c167c5b_feat_add_validator_interface_to_use_.py
+++ b/src/alembic/versions/019_92ab6c167c5b_feat_add_validator_interface_to_use_.py
@@ -1,0 +1,29 @@
+"""feat: add validator_interface to use_transaction_*
+
+Revision ID: 92ab6c167c5b
+Revises: 76a64efdbdd9
+Create Date: 2025-08-26 13:35:20.236120
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "92ab6c167c5b"
+down_revision: Union[str, None] = "76a64efdbdd9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("use_transaction_longitudinal", sa.Column("validator_interface", sa.String()))
+    op.add_column("use_transaction_location", sa.Column("validator_interface", sa.String()))
+
+
+def downgrade() -> None:
+    op.drop_column("use_transaction_longitudinal", "validator_interface")
+    op.drop_column("use_transaction_location", "validator_interface")


### PR DESCRIPTION
From [Asana](https://app.asana.com/1/15492006741476/project/546643571451005/task/1211027616797708?focus=true)

7/29: adding VALIDATOR_INTERFACE (in ODS) to dmap. additional column from use_transaction - please submit service now request.
*Dave add a ticket for this 8/12 - REQ0284902 / RITM0338851
[CHG0110025 | Change Request | ServiceNow](https://ctscubic.service-now.com/nav_to.do?uri=%2Fchange_request.do%3Fsys_id%3D33df675a2befe69472d8f4f9dd91bf6e%26sysparm_view%3D%26sysparm_domain%3Dnull%26sysparm_domain_scope%3Dnull)
Add validator_interface to use_transaction API extracts
Scheduled for 27th Aug 10 AM - 12 PM IST / 4:30 AM to 6:30 AM UTC