### PR TITLE
Adding validator_interface column to schema

### DIFF
--- a/src/cubic_loader/dmap/schemas/use_transaction_location.py
+++ b/src/cubic_loader/dmap/schemas/use_transaction_location.py
@@ -158,3 +158,4 @@ class UseTransactionalLocation(SqlBase):
     reference_notes = sa.Column(sa.String(), nullable=True)
     multi_ride_id = sa.Column(sa.BigInteger, nullable=True)
     token_id = sa.Column(sa.BigInteger, nullable=True)
+    validator_interface = sa.Column(sa.String(), nullable=True)

--- a/src/cubic_loader/dmap/schemas/use_transaction_longitudinal.py
+++ b/src/cubic_loader/dmap/schemas/use_transaction_longitudinal.py
@@ -156,3 +156,4 @@ class UseTransactionalLongitudinal(SqlBase):
     reference_notes = sa.Column(sa.String(), nullable=True)
     multi_ride_id = sa.Column(sa.BigInteger, nullable=True)
     token_id = sa.Column(sa.BigInteger, nullable=True)
+    validator_interface = sa.Column(sa.String(), nullable=True)


### PR DESCRIPTION
<!-- 
Any changes made to `src/cubic_loader/qlik/ods_tables.py` need to also be added as `odin` (github.com/mbta/odin) qlik tables.

Qlik tables, being loaded by this application, are configured to pull from from the `odin` archive location. Failure to also add tables to `odin` will result in the table data not being loaded into the dmap-import database.
 -->

<!-- Link to relevant Asana task; remove if not applicable -->
Asana task: [Add validator_interface column to schemas](https://app.asana.com/1/15492006741476/project/1210977089884035/task/1211345922056325?focus=true)
