### PR TITLE
chore: removing temporary backstop to limit Cubic API ingestion dates

### DIFF
--- a/src/cubic_loader/dmap/dmap_api.py
+++ b/src/cubic_loader/dmap/dmap_api.py
@@ -139,11 +139,13 @@ def get_api_results(url: str, db_manager: DatabaseManager) -> List[ApiResult]:  
     headers = {"apikey": apikey_from_environment(url)}
 
     # Hotfix for UseTransactionalLocation dataset
-    if url.endswith("use_transaction_location"):
-        min_start_date = "2025-12-01"
-        params = {"limit": "100", "start_date": min_start_date}
-    else:
-        params = {"limit": "100"}
+    # if url.endswith("use_transaction_location"):
+    #     min_start_date = "2025-12-01"
+    #     params = {"limit": "100", "start_date": min_start_date}
+    # else:
+    #     params = {"limit": "100"}
+
+    params = {"limit": "100"}
 
     if db_result:
         last_updated_dt: datetime.datetime = db_result[0]["last_updated"]


### PR DESCRIPTION
It looks like regeneration on the Cubic side has returned to normal, so it should be safe to remove this backstop now. Expected volume of updates from 2025 should be low, but will monitor

Asana: [[dmap] Remove backstop for dmap API regeneration](https://app.asana.com/1/15492006741476/project/1208923664771268/task/1214611994750618?focus=true)