### PR TITLE
fix: regenerating edw_payment_summary in db

### DIFF
--- a/src/alembic/versions/035_1a962fdb6931_resetting_table_edw_payment_summary.py
+++ b/src/alembic/versions/035_1a962fdb6931_resetting_table_edw_payment_summary.py
@@ -5,6 +5,7 @@ Revises: 873bd2afd66f
 Create Date: 2026-05-18 15:48:08.064966
 
 """
+
 from typing import Sequence, Union
 
 from cubic_loader.qlik.ods_qlik import CubicODSQlik
@@ -14,8 +15,8 @@ from cubic_loader.utils.postgres import DatabaseManager
 
 
 # revision identifiers, used by Alembic.
-revision: str = '1a962fdb6931'
-down_revision: Union[str, None] = '873bd2afd66f'
+revision: str = "1a962fdb6931"
+down_revision: Union[str, None] = "873bd2afd66f"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/alembic/versions/035_1a962fdb6931_resetting_table_edw_payment_summary.py
+++ b/src/alembic/versions/035_1a962fdb6931_resetting_table_edw_payment_summary.py
@@ -1,0 +1,42 @@
+"""resetting table edw_payment_summary
+
+Revision ID: 1a962fdb6931
+Revises: 873bd2afd66f
+Create Date: 2026-05-18 15:48:08.064966
+
+"""
+from typing import Sequence, Union
+
+from cubic_loader.qlik.ods_qlik import CubicODSQlik
+from cubic_loader.qlik.rds_utils import drop_table
+from cubic_loader.utils.aws import s3_delete_object
+from cubic_loader.utils.postgres import DatabaseManager
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1a962fdb6931'
+down_revision: Union[str, None] = '873bd2afd66f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    table = "EDW.PAYMENT_SUMMARY"
+    qlik_table = CubicODSQlik(table)
+    db = DatabaseManager()
+
+    # Ensure status is reset so ETL starts from source snapshot again
+    s3_delete_object(qlik_table.status_path)
+
+    fact_schema, fact_table = qlik_table.db_fact_table.split(".", maxsplit=1)
+    history_schema, history_table = qlik_table.db_history_table.split(".", maxsplit=1)
+
+    if db.table_exists(history_schema, history_table):
+        db.execute(drop_table(qlik_table.db_history_table))
+
+    if db.table_exists(fact_schema, fact_table):
+        db.truncate_table(qlik_table.db_fact_table, restart_identity=True, cascade=True)
+
+
+def downgrade() -> None:
+    return None


### PR DESCRIPTION
edw_payment_summary is working correctly in the fares data repo now after regenerating, so hopefully this will 

This uses the same functions that `CubicODSQlik` does in `snapshot_reset` if the available snapshot version doesn't match. This should delete the table and the tracking, so that the next time `CubicODSQlik` runs it will repopulate this from scratch.

Asana (including what to look for to verify this is fixed): [Comp B View Discrepancy](https://app.asana.com/1/15492006741476/project/1208949713596462/task/1211786135636254?focus=true)