### PR TITLE
Fix: Fixing change to wa160

### DIFF
--- a/src/alembic/versions/035_1018cd5a6a5e_fixing_wa160.py
+++ b/src/alembic/versions/035_1018cd5a6a5e_fixing_wa160.py
@@ -1,0 +1,34 @@
+"""Fixing wa160
+
+Revision ID: 1018cd5a6a5e
+Revises: d84dfdee27dc
+Create Date: 2026-05-26 15:58:08.446107
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+from cubic_loader.utils.postgres import DatabaseManager
+from cubic_loader.qlik.sql_strings.views import WO118, WA160_VIEW
+
+# revision identifiers, used by Alembic.
+revision: str = '1018cd5a6a5e'
+down_revision: Union[str, None] = 'd84dfdee27dc'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    db = DatabaseManager()
+    schema_check_query = "SELECT COUNT(*) from information_schema.tables WHERE table_schema = 'ods';"
+    if db.select(schema_check_query)["count"] == 0:
+        return
+
+    op.execute(WA160_VIEW)
+
+
+def downgrade() -> None:
+    pass

--- a/src/cubic_loader/qlik/sql_strings/views.py
+++ b/src/cubic_loader/qlik/sql_strings/views.py
@@ -525,7 +525,7 @@ WA160_VIEW = """
         coalesce(ut.refundable_purse_value, 0) as refundable_purse_value,
         coalesce(ut.uncollectible_amount, 0)::real / 100 as uncollectible_amount,
         tad.is_registered,
-        coalesce(ut.discount_amount, 0)::real / 100 AS discount_amount,
+        coalesce(ut.discount_applied, 0)::real / 100 AS discount_amount,
         coalesce(ut.post_pay_amount, 0)::real / 100 AS post_pay_amount
     FROM
         ods.edw_use_transaction ut


### PR DESCRIPTION
Asana task: [[ASANA_TASK_NAME](ASANA_TASK_URL)](https://app.asana.com/1/15492006741476/project/1208949713596457/task/1214939074872537?focus=true)

Resolves the incorrect column name from last week's change to WA160.
