### PR TITLE
Fix to the fix for the change to wa160

### DIFF
--- a/src/alembic/versions/035_1018cd5a6a5e_fixing_wa160.py
+++ b/src/alembic/versions/035_1018cd5a6a5e_fixing_wa160.py
@@ -1,7 +1,7 @@
 """Fixing wa160
 
 Revision ID: 1018cd5a6a5e
-Revises: d84dfdee27dc
+Revises: 873bd2afd66f
 Create Date: 2026-05-26 15:58:08.446107
 
 """


### PR DESCRIPTION
<!-- 
Any changes made to `src/cubic_loader/qlik/ods_tables.py` need to also be added as `odin` (github.com/mbta/odin) qlik tables.

Qlik tables, being loaded by this application, are configured to pull from from the `odin` archive location. Failure to also add tables to `odin` will result in the table data not being loaded into the dmap-import database.
 -->

<!-- Link to relevant Asana task; remove if not applicable -->
Asana task: [ASANA_TASK_NAME](ASANA_TASK_URL)
