### PR TITLE
Chore: Reactivate edw_frm_crdb_recon_sysconf_acqconf

### DIFF
--- a/src/cubic_loader/qlik/ods_tables.py
+++ b/src/cubic_loader/qlik/ods_tables.py
@@ -81,7 +81,7 @@ CUBIC_ODS_TABLES = [
     #    "EDW.CITATION", # Temporarily disabled, as not part of a view
     #    "EDW.KPI_AGENCY_MAP", # Temporarily disabled, as not part of a view
     #    "EDW.TOKEN_HISTORY", # Temporarily disabled, as not part of a view
-    #    "EDW.FRM_CRDB_RECON_SYSCONF_ACQCONF", # Temporarily disabled, as not part of a view
+    "EDW.FRM_CRDB_RECON_SYSCONF_ACQCONF",
     #    "EDW.TRANSIT_ACCOUNT_BALANCE", # Temporarily disabled, as not part of a view
     "EDW.CUSTOMER_DIMENSION",
     "EDW.PATRON_ORDER",


### PR DESCRIPTION
Asana task: [Data behind inedw_frm_crdb_recon_sysconf_acqconf](https://app.asana.com/1/15492006741476/project/1212830297996795/task/1215133211927180?focus=true)

Rehka reported that data in edw_frm_crdb_recon_sysconf_acqconf was behind; it turns out this table was disabled by https://github.com/mbta/dmap-import/pull/99 in January since it was apparently unused (this matches the late-December 2025 stop date of the table on DMAP currently.) This reactivates that table.