### PR TITLE
Fix: Migration to rebuild views with numeric cast

### DIFF
--- a/src/alembic/versions/036_b03c46340951_rebuild_all_views_with_new_numeric_type_.py
+++ b/src/alembic/versions/036_b03c46340951_rebuild_all_views_with_new_numeric_type_.py
@@ -1,0 +1,64 @@
+"""Rebuild all views with new 'numeric' type casting
+
+Revision ID: b03c46340951
+Revises: 1a962fdb6931
+Create Date: 2026-06-01 16:58:43.261402
+
+"""
+
+from typing import Sequence, Union
+
+from cubic_loader.qlik.sql_strings.views import (
+    FAREREV_RECOVERY_TXN_A,
+    FAREREV_RECOVERY_TXN_C,
+    WC231_CLEARING_HOUSE,
+    WC231_PASS_ID_ADHOC,
+    WC232_ACQ_CONF,
+    WC232_DEVICE_CASH_STC,
+    WC232_MISC,
+    WC232_PAYMENT_REJECTION,
+    WC232_SALE,
+    WC232_SYS_CONF,
+    WC321_CLEARING_HOUSE,
+    WO110,
+    WO150,
+)
+
+from alembic import op
+import sqlalchemy as sa
+
+from cubic_loader.utils.postgres import DatabaseManager
+
+# revision identifiers, used by Alembic.
+revision: str = "b03c46340951"
+down_revision: Union[str, None] = "1a962fdb6931"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    db = DatabaseManager()
+    schema_check_query = "SELECT COUNT(*) from information_schema.tables WHERE table_schema = 'ods';"
+    if db.select(schema_check_query)["count"] == 0:
+        return
+
+    for view in [
+        FAREREV_RECOVERY_TXN_A,
+        FAREREV_RECOVERY_TXN_C,
+        WC231_CLEARING_HOUSE,
+        WC231_PASS_ID_ADHOC,
+        WC232_ACQ_CONF,
+        WC232_DEVICE_CASH_STC,
+        WC232_MISC,
+        WC232_PAYMENT_REJECTION,
+        WC232_SALE,
+        WC232_SYS_CONF,
+        WC321_CLEARING_HOUSE,
+        WO110,
+        WO150,
+    ]:
+        op.execute(view)
+
+
+def downgrade() -> None:
+    pass

--- a/src/alembic/versions/036_b03c46340951_rebuild_all_views_with_new_numeric_type_.py
+++ b/src/alembic/versions/036_b03c46340951_rebuild_all_views_with_new_numeric_type_.py
@@ -24,6 +24,13 @@ from cubic_loader.qlik.sql_strings.views import (
     WO150,
 )
 
+from cubic_loader.qlik.sql_strings.comp_views import (
+    COMP_B_TXN_A,
+    COMP_B_TXN_C,
+    COMP_A_TXN_A,
+    COMP_A_TXN_C,
+)
+
 from alembic import op
 import sqlalchemy as sa
 
@@ -56,6 +63,10 @@ def upgrade() -> None:
         WC321_CLEARING_HOUSE,
         WO110,
         WO150,
+        COMP_B_TXN_A,
+        COMP_B_TXN_C,
+        COMP_A_TXN_A,
+        COMP_A_TXN_C,
     ]:
         op.execute(view)
 


### PR DESCRIPTION
Asana task: [WC231 report in The database - net_value is listed as integer instead of decimal](https://app.asana.com/1/15492006741476/project/1212830297996795/task/1215265033328460?focus=true)

Awhile back, there was [this ticket]( https://app.asana.com/1/15492006741476/project/1214070495342435/task/1214364566470205?focus=true) in which we were asked to put in explicit casts for columns in views which were being divided by 100 to get dollar amounts; due to how postgres type rules work, dividing an integer number of cents by (the integer constant) 100 would give an integer value, by default. I put in a ::numeric cast for all of these cases, since as long as one division value was floating point, the output would be as well. However, I didn't put in a migration to make sure this change got deployed properly to all affected views; that migration is here.