### PR TITLE
Fix issues with missing partitions for delayed tables

### DIFF
--- a/src/cubic_loader/qlik/ods_qlik.py
+++ b/src/cubic_loader/qlik/ods_qlik.py
@@ -458,10 +458,10 @@ class CubicODSQlik:
 
         except Exception as exception:
             logger.log_failure(exception)
-
-        shutil.rmtree(load_folder, ignore_errors=True)
-        self.db.vaccuum_analyze(self.db_history_table)
-        self.db.vaccuum_analyze(self.db_fact_table)
+        finally:
+            shutil.rmtree(load_folder, ignore_errors=True)
+            self.db.vaccuum_analyze(self.db_history_table)
+            self.db.vaccuum_analyze(self.db_fact_table)
 
     def cdc_check_load_folders(self, tmp_dir: str, max_folder_bytes: int = 0) -> None:
         """
@@ -551,7 +551,7 @@ class CubicODSQlik:
             # create tables and history table partitions
             # will be no-op if tables already exist
             self.db.execute(create_tables_from_schema(self.etl_status.last_schema, self.db_fact_table))
-            self.db.execute(create_history_table_partitions(self.db_history_table))
+            self.db.execute(create_history_table_partitions(self.db_history_table, self.etl_status.current_snapshot_ts))
 
             if self.etl_status.last_cdc_ts == "":
                 self.rds_snapshot_load()


### PR DESCRIPTION
Asana task: [Data behind in edw_frm_crdb_recon_sysconf_acqconf](https://app.asana.com/1/15492006741476/project/1212830297996795/task/1215133211927180?focus=true)

`edw_frm_crdb_recon_sysconf_acqconf` was disabled in December and then re-enabled in June. After being re-enabled it updated fine up to March, and then became stuck due to failing to create a partition in the history table for data past that point. This was due to the partition logic which would create new history partitions from the _date of the pipeline run_ and three months following; this meant we had a gap in the history table between March (created the last time the table updated in December) and June (when the table was re-enabled.)

To make things worse, after a day or so the table was observed to have 'caught up' to June. However, it was still missing data in the 'gap' between March and June, and had simply skipped over this period. This appears to be due to `cdc_load_folder` catching and swallowing the exception thrown by the partition failure, allowing the loop in `process_cdc_files` to go forward. As a result DMAP silently writes incomplete tables.

Two fixes in this PR:

- `run_etl` now passes the date of the current snapshot to `create_history_table_partitions`. The pre-existing logic then creates partitions for the months between the snapshot date and three months following the current date. (This will frequently try to create already-existant partitions, but this should be a no-op.)
- `cdc_load_folder` now emits any exception thrown by updating. The cleanup steps have been moved to a `finally` clause so that they still always run, even in the case on an exception. 