### PR TITLE
Disable precision element of DFM schema check

### DIFF
--- a/src/cubic_loader/qlik/ods_qlik.py
+++ b/src/cubic_loader/qlik/ods_qlik.py
@@ -253,11 +253,9 @@ class CubicODSQlik:
             .equals(truth_schema.filter(pl.col("primaryKeyPos") > 0).get_column("name"))
         ), f"primaryKey changed for table {self.table}"
 
-        # check dimenstion change(type, precision or scale)
+        # check dimenstion change(type or scale)
         dimension_check = cdc_schema.join(truth_schema, on="name", how="inner", suffix="_t").filter(
-            (pl.col("type") != pl.col("type_t"))
-            | (pl.col("precision") != pl.col("precision_t"))
-            | (pl.col("scale") != pl.col("scale_t"))
+            (pl.col("type") != pl.col("type_t")) | (pl.col("scale") != pl.col("scale_t"))
         )
 
         # AUTO convert NEW STRING type columns in DB


### PR DESCRIPTION
Asana task: [[Cubic ODS] Mid-stream schema change in EDW.PATRONAGE_SUMMARY](https://app.asana.com/1/15492006741476/project/1208923664771268/task/1214936051612847?focus=true)

Cubic recently slightly altered the schema for EDW.PATRONAGE_SUMMARY, changing the precision of the RESTRICTED_PURSE_VALUE column from 10 to 12. When a DFM after this change is ingested, the pipeline checks the schema in that DFM against the saved pre-change schema, and throws an AssertionError:

```
AssertionError: dimension change in mbta-ctd-dataplatform-archive/odin/archive/cubic_qlik/processed/cubic/ods_qlik/EDW.PATRONAGE_SUMMARY__ct/snapshot=20250131T045122Z/20260326-234256090.dfm -> RESTRICTED_PURSE_VALUE(NEW vs OLD, type:NUMERIC vs NUMERIC, precision:12 vs 10, scale:0 vs 0) 
```

This prevents the table from updating. However, precision 10 and 12 would both wind up just being an identical NUMERIC type on postgres, so this schema change doesn't matter at all to the RDS.

If we cleared out the saved schema (in s3://mbta-ctd-dataplatform-archive/cubic/ods_qlik/rds_load_status) this would regenerate from the most recent snapshot, which currently pre-dates the precision change, so this wouldn't resolve the issue.

The easiest way to fix the issue seems to be to simply remove the precision check (while retaining all other elements of the schema check) until we receive a new snapshot for EDW.PATRONAGE_SUMMARY. Once that happens we can safely revert this change.
